### PR TITLE
fix(eval): correct nested NOR/NAND expression evaluation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Truthfy
 main.pdf
+tests/*.pdf
 
 # JetBrains
 .idea

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 **Generate truth tables effortlessly — manual or automatic.**
 </center>
 
-`Truthfy` makes it easy to generate **truth tables** and **Karnaugh maps** with minimal Typst code. 
+`Truthfy` makes it easy to generate **truth tables** and **Karnaugh maps** with minimal Typst code.
 Whether you're a student, a teacher, or just dabbling in logic, Truthfy helps you visualize logic expressions — fast and clean and write your papers effortlessly.
 
 ---
@@ -46,7 +46,7 @@ Special symbols:
 
 <div id="sc"/>
 
-### 🔣 `sc`: Symbol Convention 
+### 🔣 `sc`: Symbol Convention
 Customize how `0` and `1` are rendered:
 
 ```typst
@@ -80,7 +80,7 @@ Align your table columns with Typst's native [table guide](https://typst.app/doc
 ## 🚀 Get Started — In Seconds
 
 ```typst
-#import "@preview/truthfy:0.6.0": truth-table
+#import "@preview/truthfy:0.7.0": truth-table
 
 #truth-table($A and B$, $A or B$, $A => B$, $A xor B$)
 ```
@@ -104,17 +104,54 @@ Or go manual:
 🖼️ Output:
 ![Custom Symbols](https://github.com/Thumuss/truthfy/assets/42680097/1ccf6077-5cfb-4643-b621-1dc9529b8176)
 
-🔎 See [example.typ](/example.typ) and [example.pdf](/example.pdf) for full samples.
+🔎 See the [examples/](/examples) directory for full samples.
 
 ---
 
-## 🧑‍💻 Contribute
+## 🧑‍💻 Contributing
+
+### Project layout
+
+```
+src/
+  main.typ          # Package source — all logic lives here
+examples/
+  basicExamples.typ         # General usage examples
+  logicSymbolsExample.typ   # NOR / NAND and custom symbol examples
+tests/
+  testNorNand.typ   # Assertion tests for NOR and NAND (direct and nested)
+  testBasicOps.typ  # Assertion tests for AND, OR, NOT, IMPLIES, XOR, EQUIV
+  testOrder.typ     # Assertion tests for all ordering options
+  run.sh            # Test runner script
+justfile              # just commands (see below)
+```
+
+### ⚡ just commands
+
+Install [`just`](https://github.com/casey/just) and then run any of these from the project root:
+
+| Command | Description |
+|---|---|
+| `just tests` | Compile every `tests/test_*.typ` file and assert correctness |
+| `just examples` | Compile all example files to PDF |
+| `just ci` | Run `tests` then `examples` — useful before opening a PR |
+| `just clean` | Delete all generated PDFs in `examples/` and `tests/` |
+| `just watch <file>` | Live-recompile a file on save, e.g. `just watch examples/basicExamples.typ` |
+
+### 🧪 How tests work
+
+Each test file in `tests/` passes a custom `sc` callback to `truth-table` that accumulates the computed boolean values into a Typst `state`. A `context` block at the end of the file reads the collected values and calls `assert` on each one. If any assertion fails, `typst compile` exits with a non-zero code and prints the failing message — no external test framework needed.
+
+To add a new test, create a `tests/test<name>.typ` file following the same pattern and it will be picked up automatically by `just tests`.
 
 New idea? Bug found? Head over to [Issues](https://github.com/Thumuss/truthfy/issues) and let's improve Truthfy together.
 
 ---
 
 ## 📜 Changelog Highlights
+
+### `0.7.0`
+- Fixed evaluation of nested NOR / NAND expressions ✅
 
 ### `0.6.0`
 - Support for `->` in math mode ✅

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Install [`just`](https://github.com/casey/just) and then run any of these from t
 
 | Command | Description |
 |---|---|
-| `just tests` | Compile every `tests/test_*.typ` file and assert correctness |
+| `just tests` | Compile every `tests/test*.typ` file and assert correctness |
 | `just examples` | Compile all example files to PDF |
 | `just ci` | Run `tests` then `examples` — useful before opening a PR |
 | `just clean` | Delete all generated PDFs in `examples/` and `tests/` |

--- a/justfile
+++ b/justfile
@@ -1,0 +1,13 @@
+tests:
+    bash tests/run.sh
+
+examples:
+    for f in examples/*.typ; do typst compile "$f" --root .; done
+
+ci: tests examples
+
+clean:
+    rm -f examples/*.pdf tests/*.pdf
+
+watch file:
+    typst watch "{{file}}" --root .

--- a/src/main.typ
+++ b/src/main.typ
@@ -1,5 +1,5 @@
 // Symbols you can use for logical implication. \
-// See [Material_conditional](https://en.wikipedia.org/wiki/Material_conditional>)
+// See [Material_conditional](https://en.wikipedia.org/wiki/Material_conditional)
 #let impliesSymbols = ("⇒", "→", "⊃")
 
 // Symbols you can use for logical equivalence. \
@@ -10,11 +10,11 @@
 // See [Negation](https://en.wikipedia.org/wiki/Negation)
 #let negationSymbols = ("¬", "∼", "!", "′")
 
-// Symbols you can use for logical conjuction. \
+// Symbols you can use for logical conjunction. \
 // See [Logical_conjunction](https://en.wikipedia.org/wiki/Logical_conjunction)
 #let conjunctionSymbols = ("∧", "·", "&")
 
-// Symbols you can use for logical conjuction. \
+// Symbols you can use for logical disjunction. \
 // See [Logical_disjunction](https://en.wikipedia.org/wiki/Logical_disjunction)
 #let disjunctionSymbols = ("∨", "\\+", "∥")
 
@@ -58,23 +58,22 @@
   // *[WARNING]:* Can change between version of typst. \
   // Beware it might not work on other version than the latest.
   let _strstack(obj) = {
+    let _proc(subobj) = {
+      if subobj.has("text") {
+        subobj.text
+      } else if subobj.fields().len() == 0 {
+        " "
+      } else if subobj.has("b") {
+        subobj.base.text + "_" + subobj.b.text
+      } else {
+        _strstack(subobj.fields())
+      }
+    }
     let i = obj.at("body", default: false)
     if i == false {
       return obj
         .values()
-        .map(a => a.map(subobj => if subobj.has("text") {
-          subobj.text
-        } else {
-          if subobj.fields().len() == 0 {
-            " "
-          } else {
-            if (subobj.has("b")) {
-              subobj.base.text + "_" + subobj.b.text
-            } else {
-              _strstack(subobj.fields())
-            }
-          }
-        }))
+        .map(a => a.map(_proc))
     } else if obj.body.has("b") {
       return obj.body.base.text + "_" + obj.body.b.text
     } else if not obj.body.has("children") {
@@ -83,21 +82,7 @@
       return obj
         .body
         .children
-        .map(subobj => {
-          if subobj.has("text") {
-            subobj.text
-          } else {
-            if subobj.fields().len() == 0 {
-              " "
-            } else {
-              if (subobj.has("b")) {
-                subobj.base.text + "_" + subobj.b.text
-              } else {
-                _strstack(subobj.fields())
-              }
-            }
-          }
-        })
+        .map(_proc)
         .flatten()
         .join("")
     }
@@ -128,17 +113,17 @@
 
     // ↑ Approach
     while true {
-      let pos = text.match(regex("([(]+.*[)]|[a-zA-Z](_\d+)?)+[ ]*↑[ ]*([(]+.*[)]|[a-zA-Z](_\d+)?)+"))
+      let pos = text.match(regex("([(]+.*[)]|[a-zA-Z]+(_\d+)?)+[ ]*↑[ ]*([(]+.*[)]|[a-zA-Z]+(_\d+)?)+"))
       if (pos != none) {
-        text = text.replace(pos.text, "not(" + pos.text.replace("↑", "and", count: 1) + ")")
+        text = text.replace(pos.text, "not(" + pos.captures.at(0) + " and " + pos.captures.at(2) + ")")
       } else { break }
     }
 
     // ↓ Approach
     while true {
-      let pos = text.match(regex("([(]+.*[)]|[a-zA-Z](_\d+)?)+[ ]*↓[ ]*([(]+.*[)]|[a-zA-Z](_\d+)?)+"))
+      let pos = text.match(regex("([(]+.*[)]|[a-zA-Z]+(_\d+)?)+[ ]*↓[ ]*([(]+.*[)]|[a-zA-Z]+(_\d+)?)+"))
       if (pos != none) {
-        text = text.replace(pos.text, "not(" + pos.text.replace("↓", "or", count: 1) + ")")
+        text = text.replace(pos.text, "not(" + pos.captures.at(0) + " or " + pos.captures.at(2) + ")")
       } else { break }
     }
 

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Run all test*.typ files. Compilation failure = test failure.
+# Usage: ./tests/run.sh  (from project root or tests/ directory)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PASS=0
+FAIL=0
+
+for f in "$SCRIPT_DIR"/test*.typ; do
+  name="$(basename "$f")"
+  out="$SCRIPT_DIR/${name%.typ}.pdf"
+  if typst compile "$f" "$out" --root "$ROOT" 2>&1; then
+    echo "PASS  $name"
+    rm -f "$out"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL  $name"
+    FAIL=$((FAIL + 1))
+  fi
+done
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/tests/testBasicOps.typ
+++ b/tests/testBasicOps.typ
@@ -1,0 +1,124 @@
+// Tests for AND, OR, NOT, IMPLIES (=>), XOR, and EQUIV (<=>).
+// Row order (default):
+//   1 variable (p):     (F), (T)
+//   2 variables (p, q): (F,F), (T,F), (F,T), (T,T)
+// sc step = bL + iL values per row; expression is the last iL slots.
+
+#import "../src/main.typ": *
+#set page(width: auto, height: auto)
+
+// ── NOT ──────────────────────────────────────────────────────────────────────
+// 1 var + 1 expr, step=2: expr at [1, 3]
+// NOT(F)=T, NOT(T)=F
+
+#let s-not = state("not-vals", ())
+#let sc-not(v) = {
+  s-not.update(a => a + (v,))
+  if v { "1" } else { "0" }
+}
+
+#truth-table(sc: sc-not, $not p$)
+
+#context {
+  let v = s-not.get()
+  assert(v.at(1) == true,  message: "NOT(F) should be T")
+  assert(v.at(3) == false, message: "NOT(T) should be F")
+}
+
+// ── AND ──────────────────────────────────────────────────────────────────────
+// 2 vars + 1 expr, step=3: expr at [2, 5, 8, 11]
+// (F,F)=F (T,F)=F (F,T)=F (T,T)=T
+
+#let s-and = state("and-vals", ())
+#let sc-and(v) = {
+  s-and.update(a => a + (v,))
+  if v { "1" } else { "0" }
+}
+
+#truth-table(sc: sc-and, $p and q$)
+
+#context {
+  let v = s-and.get()
+  assert(v.at(2)  == false, message: "AND(F,F) should be F")
+  assert(v.at(5)  == false, message: "AND(T,F) should be F")
+  assert(v.at(8)  == false, message: "AND(F,T) should be F")
+  assert(v.at(11) == true,  message: "AND(T,T) should be T")
+}
+
+// ── OR ───────────────────────────────────────────────────────────────────────
+// (F,F)=F (T,F)=T (F,T)=T (T,T)=T
+
+#let s-or = state("or-vals", ())
+#let sc-or(v) = {
+  s-or.update(a => a + (v,))
+  if v { "1" } else { "0" }
+}
+
+#truth-table(sc: sc-or, $p or q$)
+
+#context {
+  let v = s-or.get()
+  assert(v.at(2)  == false, message: "OR(F,F) should be F")
+  assert(v.at(5)  == true,  message: "OR(T,F) should be T")
+  assert(v.at(8)  == true,  message: "OR(F,T) should be T")
+  assert(v.at(11) == true,  message: "OR(T,T) should be T")
+}
+
+// ── IMPLIES ──────────────────────────────────────────────────────────────────
+// p => q  ≡  ¬p ∨ q
+// (F,F)=T (T,F)=F (F,T)=T (T,T)=T
+
+#let s-imp = state("imp-vals", ())
+#let sc-imp(v) = {
+  s-imp.update(a => a + (v,))
+  if v { "1" } else { "0" }
+}
+
+#truth-table(sc: sc-imp, $p => q$)
+
+#context {
+  let v = s-imp.get()
+  assert(v.at(2)  == true,  message: "IMPLIES(F,F) should be T")
+  assert(v.at(5)  == false, message: "IMPLIES(T,F) should be F")
+  assert(v.at(8)  == true,  message: "IMPLIES(F,T) should be T")
+  assert(v.at(11) == true,  message: "IMPLIES(T,T) should be T")
+}
+
+// ── XOR ──────────────────────────────────────────────────────────────────────
+// (F,F)=F (T,F)=T (F,T)=T (T,T)=F
+
+#let s-xor = state("xor-vals", ())
+#let sc-xor(v) = {
+  s-xor.update(a => a + (v,))
+  if v { "1" } else { "0" }
+}
+
+#truth-table(sc: sc-xor, $p xor q$)
+
+#context {
+  let v = s-xor.get()
+  assert(v.at(2)  == false, message: "XOR(F,F) should be F")
+  assert(v.at(5)  == true,  message: "XOR(T,F) should be T")
+  assert(v.at(8)  == true,  message: "XOR(F,T) should be T")
+  assert(v.at(11) == false, message: "XOR(T,T) should be F")
+}
+
+// ── EQUIV ─────────────────────────────────────────────────────────────────────
+// p <=> q  ≡  (p => q) ∧ (q => p)
+// (F,F)=T (T,F)=F (F,T)=F (T,T)=T
+
+#let s-eq = state("eq-vals", ())
+#let sc-eq(v) = {
+  s-eq.update(a => a + (v,))
+  if v { "1" } else { "0" }
+}
+
+#truth-table(sc: sc-eq, $p <=> q$)
+
+#context {
+  let v = s-eq.get()
+  assert(v.at(2)  == true,  message: "EQUIV(F,F) should be T")
+  assert(v.at(5)  == false, message: "EQUIV(T,F) should be F")
+  assert(v.at(8)  == false, message: "EQUIV(F,T) should be F")
+  assert(v.at(11) == true,  message: "EQUIV(T,T) should be T")
+}

--- a/tests/testNorNand.typ
+++ b/tests/testNorNand.typ
@@ -1,0 +1,55 @@
+// Tests for NOR (↓) and NAND (↑) operators, including nested expressions.
+// Row order (default, 2 vars x/y): (F,F), (T,F), (F,T), (T,T)
+// sc fires on: x, y, expr1, expr2, expr3, expr4  →  step = 6 per row
+// expr1 = x NOR y          → indices 2, 8, 14, 20
+// expr2 = (x↓x)↓(y↓y)      → indices 3, 9, 15, 21  (equals x AND y)
+// expr3 = x NAND y         → indices 4, 10, 16, 22
+// expr4 = (x↑x)↑(y↑y)      → indices 5, 11, 17, 23  (equals x OR y)
+
+#import "../src/main.typ": *
+#set page(width: auto, height: auto)
+
+#let nor  = math.arrow.b  // ↓
+#let nand = math.arrow.t  // ↑
+
+#let s = state("nor-nand-vals", ())
+#let sc(v) = {
+  s.update(a => a + (v,))
+  if v { "1" } else { "0" }
+}
+
+#truth-table(
+  sc: sc,
+  $x nor y$,
+  $(x nor x) nor (y nor y)$,
+  $x nand y$,
+  $(x nand x) nand (y nand y)$,
+)
+
+#context {
+  let v = s.get()
+
+  // ── x NOR y ──────────────────────────────────────────────────────────────
+  assert(v.at(2)  == true,  message: "NOR(F,F) should be T")
+  assert(v.at(8)  == false, message: "NOR(T,F) should be F")
+  assert(v.at(14) == false, message: "NOR(F,T) should be F")
+  assert(v.at(20) == false, message: "NOR(T,T) should be F")
+
+  // ── (x↓x)↓(y↓y) = x AND y ───────────────────────────────────────────────
+  assert(v.at(3)  == false, message: "nested-NOR(F,F) = AND(F,F) should be F")
+  assert(v.at(9)  == false, message: "nested-NOR(T,F) = AND(T,F) should be F")
+  assert(v.at(15) == false, message: "nested-NOR(F,T) = AND(F,T) should be F")
+  assert(v.at(21) == true,  message: "nested-NOR(T,T) = AND(T,T) should be T")
+
+  // ── x NAND y ─────────────────────────────────────────────────────────────
+  assert(v.at(4)  == true,  message: "NAND(F,F) should be T")
+  assert(v.at(10) == true,  message: "NAND(T,F) should be T")
+  assert(v.at(16) == true,  message: "NAND(F,T) should be T")
+  assert(v.at(22) == false, message: "NAND(T,T) should be F")
+
+  // ── (x↑x)↑(y↑y) = x OR y ────────────────────────────────────────────────
+  assert(v.at(5)  == false, message: "nested-NAND(F,F) = OR(F,F) should be F")
+  assert(v.at(11) == true,  message: "nested-NAND(T,F) = OR(T,F) should be T")
+  assert(v.at(17) == true,  message: "nested-NAND(F,T) = OR(F,T) should be T")
+  assert(v.at(23) == true,  message: "nested-NAND(T,T) = OR(T,T) should be T")
+}

--- a/tests/testOrder.typ
+++ b/tests/testOrder.typ
@@ -1,0 +1,292 @@
+// Tests for all `order` option combinations.
+//
+// The `order` string is a space-separated set of keywords:
+//   "alphabetical"  — sort variables alphabetically before display
+//   "reverse"       — reverse the variable column order
+//   "textbook"      — rightmost variable increments fastest (binary counting)
+//
+// These can be combined: "alphabetical reverse", "alphabetical textbook", etc.
+//
+// ── How row order is determined ─────────────────────────────────────────────
+// For each column col (1-based):
+//   raised = "textbook" ? 2^(bL - col)  :  2^(col - 1)
+//   value  = not even(floor(row / raised))
+//
+// sc fires as [col1_val, col2_val, expr_val] per row.
+// For 2 variables + 1 expression: step = 3, indices per row k = [3k, 3k+1, 3k+2].
+//
+
+#import "../src/main.typ": *
+#set page(width: auto, height: auto)
+
+// ── 1. Default order ─────────────────────────────────────────────────────────
+// base = [x, y]  (extraction order)
+// col 1 → x, raised = 1  (x changes every row — fastest)
+// col 2 → y, raised = 2  (y changes every 2 rows — slowest)
+// Rows: (x=F,y=F), (x=T,y=F), (x=F,y=T), (x=T,y=T)
+// x=>y:      T         F         T          T
+// Expected state: [F,F,T, T,F,F, F,T,T, T,T,T]
+
+#let s1 = state("order-default", ())
+#let sc1(v) = { s1.update(a => a + (v,)); if v {"1"} else {"0"} }
+
+#truth-table(sc: sc1, $x => y$)
+
+#context {
+  let v = s1.get()
+  assert(v.at(0) == false, message: "default row0 col1: x=F")
+  assert(v.at(1) == false, message: "default row0 col2: y=F")
+  assert(v.at(2) == true,  message: "default row0 expr: F=>F=T")
+  assert(v.at(3) == true,  message: "default row1 col1: x=T")
+  assert(v.at(4) == false, message: "default row1 col2: y=F")
+  assert(v.at(5) == false, message: "default row1 expr: T=>F=F")
+  assert(v.at(6) == false, message: "default row2 col1: x=F")
+  assert(v.at(7) == true,  message: "default row2 col2: y=T")
+  assert(v.at(8) == true,  message: "default row2 expr: F=>T=T")
+  assert(v.at(9)  == true, message: "default row3 col1: x=T")
+  assert(v.at(10) == true, message: "default row3 col2: y=T")
+  assert(v.at(11) == true, message: "default row3 expr: T=>T=T")
+}
+
+// ── 2. Textbook order ────────────────────────────────────────────────────────
+// base = [x, y]  (unchanged)
+// col 1 → x, raised = 2  (x changes every 2 rows — slowest)
+// col 2 → y, raised = 1  (y changes every row — fastest)
+// Rows: (x=F,y=F), (x=F,y=T), (x=T,y=F), (x=T,y=T)
+// x=>y:      T         T         F          T
+// Expected state: [F,F,T, F,T,T, T,F,F, T,T,T]
+//
+// This is the order requested in issue #19: rightmost variable increments fastest.
+
+#let s2 = state("order-textbook", ())
+#let sc2(v) = { s2.update(a => a + (v,)); if v {"1"} else {"0"} }
+
+#truth-table(order: "textbook", sc: sc2, $x => y$)
+
+#context {
+  let v = s2.get()
+  assert(v.at(0) == false, message: "textbook row0 col1: x=F")
+  assert(v.at(1) == false, message: "textbook row0 col2: y=F")
+  assert(v.at(2) == true,  message: "textbook row0 expr: F=>F=T")
+  assert(v.at(3) == false, message: "textbook row1 col1: x=F")
+  assert(v.at(4) == true,  message: "textbook row1 col2: y=T")
+  assert(v.at(5) == true,  message: "textbook row1 expr: F=>T=T")
+  assert(v.at(6) == true,  message: "textbook row2 col1: x=T")
+  assert(v.at(7) == false, message: "textbook row2 col2: y=F")
+  assert(v.at(8) == false, message: "textbook row2 expr: T=>F=F")
+  assert(v.at(9)  == true, message: "textbook row3 col1: x=T")
+  assert(v.at(10) == true, message: "textbook row3 col2: y=T")
+  assert(v.at(11) == true, message: "textbook row3 expr: T=>T=T")
+}
+
+// ── 3. Textbook with 3 variables ─────────────────────────────────────────────
+// base = [x, y, z]; col 1→x (slowest), col 2→y, col 3→z (fastest)
+// Rows: (F,F,F),(F,F,T),(F,T,F),(F,T,T),(T,F,F),(T,F,T),(T,T,F),(T,T,T)
+// x AND y AND z: only T on the last row
+// step = 4 per row (3 vars + 1 expr); expr at indices 3,7,11,15,19,23,27,31
+
+#let s3 = state("order-textbook-3var", ())
+#let sc3(v) = { s3.update(a => a + (v,)); if v {"1"} else {"0"} }
+
+#truth-table(order: "textbook", sc: sc3, $x and y and z$)
+
+#context {
+  let v = s3.get()
+  // Verify column ordering: x slowest, z fastest
+  assert(v.at(0) == false, message: "3var row0 x=F")
+  assert(v.at(1) == false, message: "3var row0 y=F")
+  assert(v.at(2) == false, message: "3var row0 z=F")
+  assert(v.at(4) == false, message: "3var row1 x=F")
+  assert(v.at(5) == false, message: "3var row1 y=F")
+  assert(v.at(6) == true,  message: "3var row1 z=T")
+  assert(v.at(8) == false, message: "3var row2 x=F")
+  assert(v.at(9) == true,  message: "3var row2 y=T")
+  assert(v.at(10) == false, message: "3var row2 z=F")
+  assert(v.at(16) == true, message: "3var row4 x=T")
+  assert(v.at(17) == false, message: "3var row4 y=F")
+  assert(v.at(18) == false, message: "3var row4 z=F")
+  // Verify expression values
+  assert(v.at(3)  == false, message: "AND(F,F,F)=F")
+  assert(v.at(7)  == false, message: "AND(F,F,T)=F")
+  assert(v.at(11) == false, message: "AND(F,T,F)=F")
+  assert(v.at(15) == false, message: "AND(F,T,T)=F")
+  assert(v.at(19) == false, message: "AND(T,F,F)=F")
+  assert(v.at(23) == false, message: "AND(T,F,T)=F")
+  assert(v.at(27) == false, message: "AND(T,T,F)=F")
+  assert(v.at(31) == true,  message: "AND(T,T,T)=T")
+}
+
+// ── 4. Reverse order ─────────────────────────────────────────────────────────
+// base = [x, y] → reversed → [y, x]
+// col 1 → y, raised = 1  (y changes every row — fastest)
+// col 2 → x, raised = 2  (x changes every 2 rows — slowest)
+// Rows: (y=F,x=F), (y=T,x=F), (y=F,x=T), (y=T,x=T)
+// x=>y:      T         T         F          T
+// Expected state: [F,F,T, T,F,T, F,T,F, T,T,T]
+
+#let s4 = state("order-reverse", ())
+#let sc4(v) = { s4.update(a => a + (v,)); if v {"1"} else {"0"} }
+
+#truth-table(order: "reverse", sc: sc4, $x => y$)
+
+#context {
+  let v = s4.get()
+  assert(v.at(0) == false, message: "reverse row0 col1: y=F")
+  assert(v.at(1) == false, message: "reverse row0 col2: x=F")
+  assert(v.at(2) == true,  message: "reverse row0 expr: F=>F=T")
+  assert(v.at(3) == true,  message: "reverse row1 col1: y=T")
+  assert(v.at(4) == false, message: "reverse row1 col2: x=F")
+  assert(v.at(5) == true,  message: "reverse row1 expr: F=>T=T")
+  assert(v.at(6) == false, message: "reverse row2 col1: y=F")
+  assert(v.at(7) == true,  message: "reverse row2 col2: x=T")
+  assert(v.at(8) == false, message: "reverse row2 expr: T=>F=F")
+  assert(v.at(9)  == true, message: "reverse row3 col1: y=T")
+  assert(v.at(10) == true, message: "reverse row3 col2: x=T")
+  assert(v.at(11) == true, message: "reverse row3 expr: T=>T=T")
+}
+
+// ── 5. Reverse textbook order ─────────────────────────────────────────────────
+// base = [x, y] → reversed → [y, x]
+// col 1 → y, raised = 2  (y changes every 2 rows — slowest)
+// col 2 → x, raised = 1  (x changes every row — fastest)
+// Rows: (y=F,x=F), (y=F,x=T), (y=T,x=F), (y=T,x=T)
+// x=>y:      T         F         T          T
+// Expected state: [F,F,T, F,T,F, T,F,T, T,T,T]
+
+#let s5 = state("order-reverse-textbook", ())
+#let sc5(v) = { s5.update(a => a + (v,)); if v {"1"} else {"0"} }
+
+#truth-table(order: "reverse textbook", sc: sc5, $x => y$)
+
+#context {
+  let v = s5.get()
+  assert(v.at(0) == false, message: "rev+tb row0 col1: y=F")
+  assert(v.at(1) == false, message: "rev+tb row0 col2: x=F")
+  assert(v.at(2) == true,  message: "rev+tb row0 expr: F=>F=T")
+  assert(v.at(3) == false, message: "rev+tb row1 col1: y=F")
+  assert(v.at(4) == true,  message: "rev+tb row1 col2: x=T")
+  assert(v.at(5) == false, message: "rev+tb row1 expr: T=>F=F")
+  assert(v.at(6) == true,  message: "rev+tb row2 col1: y=T")
+  assert(v.at(7) == false, message: "rev+tb row2 col2: x=F")
+  assert(v.at(8) == true,  message: "rev+tb row2 expr: F=>T=T")
+  assert(v.at(9)  == true, message: "rev+tb row3 col1: y=T")
+  assert(v.at(10) == true, message: "rev+tb row3 col2: x=T")
+  assert(v.at(11) == true, message: "rev+tb row3 expr: T=>T=T")
+}
+
+// ── 6. Alphabetical order ─────────────────────────────────────────────────────
+// Using $b => a$ so extraction order [b, a] ≠ alphabetical order [a, b].
+// base = [b, a] → sorted → [a, b]
+// col 1 → a, raised = 1  (a changes every row — fastest)
+// col 2 → b, raised = 2  (b changes every 2 rows — slowest)
+// Rows: (a=F,b=F), (a=T,b=F), (a=F,b=T), (a=T,b=T)
+// b=>a:      T         T         F          T
+// Expected state: [F,F,T, T,F,T, F,T,F, T,T,T]
+
+#let s6 = state("order-alphabetical", ())
+#let sc6(v) = { s6.update(a => a + (v,)); if v {"1"} else {"0"} }
+
+#truth-table(order: "alphabetical", sc: sc6, $b => a$)
+
+#context {
+  let v = s6.get()
+  assert(v.at(0) == false, message: "alpha row0 col1: a=F")
+  assert(v.at(1) == false, message: "alpha row0 col2: b=F")
+  assert(v.at(2) == true,  message: "alpha row0 expr: F=>F=T")
+  assert(v.at(3) == true,  message: "alpha row1 col1: a=T")
+  assert(v.at(4) == false, message: "alpha row1 col2: b=F")
+  assert(v.at(5) == true,  message: "alpha row1 expr: F=>T=T")
+  assert(v.at(6) == false, message: "alpha row2 col1: a=F")
+  assert(v.at(7) == true,  message: "alpha row2 col2: b=T")
+  assert(v.at(8) == false, message: "alpha row2 expr: T=>F=F")
+  assert(v.at(9)  == true, message: "alpha row3 col1: a=T")
+  assert(v.at(10) == true, message: "alpha row3 col2: b=T")
+  assert(v.at(11) == true, message: "alpha row3 expr: T=>T=T")
+}
+
+// ── 7. Alphabetical textbook order ────────────────────────────────────────────
+// base = [b, a] → sorted → [a, b]
+// col 1 → a, raised = 2  (a changes every 2 rows — slowest)
+// col 2 → b, raised = 1  (b changes every row — fastest)
+// Rows: (a=F,b=F), (a=F,b=T), (a=T,b=F), (a=T,b=T)
+// b=>a:      T         F         T          T
+// Expected state: [F,F,T, F,T,F, T,F,T, T,T,T]
+
+#let s7 = state("order-alphabetical-textbook", ())
+#let sc7(v) = { s7.update(a => a + (v,)); if v {"1"} else {"0"} }
+
+#truth-table(order: "alphabetical textbook", sc: sc7, $b => a$)
+
+#context {
+  let v = s7.get()
+  assert(v.at(0) == false, message: "alpha+tb row0 col1: a=F")
+  assert(v.at(1) == false, message: "alpha+tb row0 col2: b=F")
+  assert(v.at(2) == true,  message: "alpha+tb row0 expr: F=>F=T")
+  assert(v.at(3) == false, message: "alpha+tb row1 col1: a=F")
+  assert(v.at(4) == true,  message: "alpha+tb row1 col2: b=T")
+  assert(v.at(5) == false, message: "alpha+tb row1 expr: T=>F=F")
+  assert(v.at(6) == true,  message: "alpha+tb row2 col1: a=T")
+  assert(v.at(7) == false, message: "alpha+tb row2 col2: b=F")
+  assert(v.at(8) == true,  message: "alpha+tb row2 expr: F=>T=T")
+  assert(v.at(9)  == true, message: "alpha+tb row3 col1: a=T")
+  assert(v.at(10) == true, message: "alpha+tb row3 col2: b=T")
+  assert(v.at(11) == true, message: "alpha+tb row3 expr: T=>T=T")
+}
+
+// ── 8. Alphabetical reverse order ─────────────────────────────────────────────
+// base = [b, a] → sorted → [a, b] → reversed → [b, a]
+// col 1 → b, raised = 1  (b changes every row — fastest)
+// col 2 → a, raised = 2  (a changes every 2 rows — slowest)
+// Rows: (b=F,a=F), (b=T,a=F), (b=F,a=T), (b=T,a=T)
+// b=>a:      T         F         T          T
+// Expected state: [F,F,T, T,F,F, F,T,T, T,T,T]
+
+#let s8 = state("order-alphabetical-reverse", ())
+#let sc8(v) = { s8.update(a => a + (v,)); if v {"1"} else {"0"} }
+
+#truth-table(order: "alphabetical reverse", sc: sc8, $b => a$)
+
+#context {
+  let v = s8.get()
+  assert(v.at(0) == false, message: "alpha+rev row0 col1: b=F")
+  assert(v.at(1) == false, message: "alpha+rev row0 col2: a=F")
+  assert(v.at(2) == true,  message: "alpha+rev row0 expr: F=>F=T")
+  assert(v.at(3) == true,  message: "alpha+rev row1 col1: b=T")
+  assert(v.at(4) == false, message: "alpha+rev row1 col2: a=F")
+  assert(v.at(5) == false, message: "alpha+rev row1 expr: T=>F=F")
+  assert(v.at(6) == false, message: "alpha+rev row2 col1: b=F")
+  assert(v.at(7) == true,  message: "alpha+rev row2 col2: a=T")
+  assert(v.at(8) == true,  message: "alpha+rev row2 expr: F=>T=T")
+  assert(v.at(9)  == true, message: "alpha+rev row3 col1: b=T")
+  assert(v.at(10) == true, message: "alpha+rev row3 col2: a=T")
+  assert(v.at(11) == true, message: "alpha+rev row3 expr: T=>T=T")
+}
+
+// ── 9. Alphabetical reverse textbook order ────────────────────────────────────
+// base = [b, a] → sorted → [a, b] → reversed → [b, a]
+// col 1 → b, raised = 2  (b changes every 2 rows — slowest)
+// col 2 → a, raised = 1  (a changes every row — fastest)
+// Rows: (b=F,a=F), (b=F,a=T), (b=T,a=F), (b=T,a=T)
+// b=>a:      T         T         F          T
+// Expected state: [F,F,T, F,T,T, T,F,F, T,T,T]
+
+#let s9 = state("order-alphabetical-reverse-textbook", ())
+#let sc9(v) = { s9.update(a => a + (v,)); if v {"1"} else {"0"} }
+
+#truth-table(order: "alphabetical reverse textbook", sc: sc9, $b => a$)
+
+#context {
+  let v = s9.get()
+  assert(v.at(0) == false, message: "alpha+rev+tb row0 col1: b=F")
+  assert(v.at(1) == false, message: "alpha+rev+tb row0 col2: a=F")
+  assert(v.at(2) == true,  message: "alpha+rev+tb row0 expr: F=>F=T")
+  assert(v.at(3) == false, message: "alpha+rev+tb row1 col1: b=F")
+  assert(v.at(4) == true,  message: "alpha+rev+tb row1 col2: a=T")
+  assert(v.at(5) == true,  message: "alpha+rev+tb row1 expr: F=>T=T")
+  assert(v.at(6) == true,  message: "alpha+rev+tb row2 col1: b=T")
+  assert(v.at(7) == false, message: "alpha+rev+tb row2 col2: a=F")
+  assert(v.at(8) == false, message: "alpha+rev+tb row2 expr: T=>F=F")
+  assert(v.at(9)  == true, message: "alpha+rev+tb row3 col1: b=T")
+  assert(v.at(10) == true, message: "alpha+rev+tb row3 col2: a=T")
+  assert(v.at(11) == true, message: "alpha+rev+tb row3 expr: T=>T=T")
+}


### PR DESCRIPTION
<h1>Summary</h1>
<ul>
<li>Fixes incorrect evaluation of nested NOR/NAND expressions — the root cause and main motivation for this PR</li>
<li>Adds a test suite so regressions like this are caught automatically</li>
<li>Adds a <code>justfile</code> for a consistent developer workflow</li>
<li>Updates the README with a Contributing section and fixes stale references</li>
</ul>
<h1>Bug fix — nested NOR / NAND evaluation (<code>src/main.typ</code>)</h1>
<p>Expressions like <code>(x↓x)↓(y↓y)</code> — which should equal <code>x AND y</code> — were producing incorrect results.</p>
<p>The <code>↓</code> and <code>↑</code> handlers used:</p>
<pre><code class="language-typst">pos.text.replace("↓", "or", count: 1)
</code></pre>
<p>to rewrite the operator, but this always replaced the first <code>↓</code> in the matched string. For a nested expression like <code>(A↓B)↓(C↓D)</code>, that means the inner operator in the first operand was rewritten instead of the outer operator.</p>
<p>This PR fixes that by using <code>pos.captures</code> to reference the left and right operands directly, mirroring the already-correct <code>⇒</code> handler. It also changes the regex from <code>[a-zA-Z]</code> to <code>[a-zA-Z]+</code> so multi-letter literals like <code>true</code> and <code>false</code> are captured as whole tokens rather than letter by letter.</p>
<h1>Test suite (<code>tests/</code>)</h1>
<p>Adds three test files driven by <code>tests/run.sh</code>. Each test passes a custom <code>sc</code> callback to <code>truth-table</code> that accumulates computed values into a Typst state; a <code>context</code> block then asserts each value. Compilation failure = test failure, so no external framework is needed.</p>

File | Coverage
-- | --
testNorNand.typ | NOR and NAND — direct and nested cases, including the fixed bug
testBasicOps.typ | AND, OR, NOT, IMPLIES, XOR, EQUIV
testOrder.typ | All order option combinations; addresses issue #19


<h1>Other housekeeping</h1>
<ul>
<li><strong>README</strong>
<ul>
<li>Added a Contributing section covering project layout, <code>just</code> commands, and test strategy</li>
<li>Updated import version <code>0.6.0</code> → <code>0.7.0</code></li>
<li>Fixed broken <code>example.typ</code> link</li>
<li>Added <code>0.7.0</code> changelog entry</li>
</ul>
</li>
<li><strong><code>src/main.typ</code></strong>
<ul>
<li>Fixed two comment typos (<code>conjuction</code> → <code>conjunction</code>, plus corresponding disjunction typo)</li>
<li>Fixed a malformed Wikipedia URL</li>
<li>Extracted duplicated <code>subobj</code> processing in <code>_strstack</code> into a local <code>_proc</code> helper</li>
</ul>
</li>
<li><strong><code>.gitignore</code></strong>
<ul>
<li>Added <code>tests/*.pdf</code></li>
</ul>
</li>
</ul>
<h1>Test plan</h1>
<ul>
<li><code>just ci</code> passes (<code>3</code> tests and <code>2</code> examples compile cleanly)</li>
<li>Verify <code>(x↓x)↓(y↓y)</code> produces the same truth table as <code>x AND y</code> — true only when both inputs are <code>1</code></li>
<li>Verify <code>(x↑x)↑(y↑y)</code> produces the same truth table as <code>x OR y</code></li>
<li>Fixes #16, #17, #18</li>
</ul>