### PR TITLE
docs: fix README alignment typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ You can use any combination of these values: "alphabetical", "reverse", "textboo
 ## `align`
 
 Align your table, using Typst Table
-alignement [https://typst.app/docs/guides/table-guide/#alignment](https://typst.app/docs/guides/table-guide/#alignment).
+alignment [https://typst.app/docs/guides/table-guide/#alignment](https://typst.app/docs/guides/table-guide/#alignment).
 
 # Examples
 


### PR DESCRIPTION
## Summary

Fixes a small spelling typo in the README: `alignement` -> `alignment` in the `align` option section.

## Validation

- `rg -n 'alignement|alignment|Typst Table|table-guide' README.md`
- `git diff --check`

## Notes

This only changes README prose; no package code or examples were changed.
