### PR TITLE
docs: fix README grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Syntax:
 ```typst
 #let sc(symb) = {
     if (symb) {
-        "an one"
+        "a one"
     } else {
         "a zero"
     }
@@ -44,7 +44,7 @@ Reverse your table, see issue #3
 
 ## `order`
 
-Change the order of your symbol.
+Change the order of your symbols.
 
 You can use any combination of these values: "alphabetical", "reverse", "textbook".
 


### PR DESCRIPTION
## Summary
- fix the example output text from `an one` to `a one`
- make the `order` option description refer to multiple symbols

This addresses a small remaining README grammar slice from #10.

## Tests
- `rg -n "an one|a one|order of your symbol|order of your symbols|sc\(symb\)|alphabetical" README.md`
- `git diff --check`

No runtime tests were run because this only changes README prose/example text.